### PR TITLE
Devectorize bfs

### DIFF
--- a/Graph500/clean-src/bfs.jl
+++ b/Graph500/clean-src/bfs.jl
@@ -15,6 +15,7 @@ function bfs(G, root)
     # vertex list to visit
     vlist = zeros(Int64, N)
     vlist[1] = root
+    rowval = G.rowval
 
     lastk = 1
     for k = 1:N
@@ -23,18 +24,18 @@ function bfs(G, root)
             break
         end
 
-        # get a vector of end vertices for this start vertex
-        I = (G[:, v]).nzind
-
-        # filter out visited vertices
-        nxt = filter((x) -> parents[x] == 0, I)    
-
-        # set the parent for all these end vertices
-        parents[nxt] = v
-
-        # have to visit all these end vertices
-        vlist[lastk + (1:length(nxt))] = nxt
-        lastk += length(nxt)
+        # loop through end vertices for this start vertex
+        for nz in nzrange(G, v)
+            i = rowval[nz]
+            # filter out visited vertices
+            if parents[i] == 0
+                # set the parent for all these end vertices
+                parents[i] = v
+                lastk += 1
+                # have to visit all these end vertices
+                vlist[lastk] = i
+            end
+        end
     end
     return parents
 end


### PR DESCRIPTION
Don't make SparseVector copy of each column of G then filter copy of indices

If I'm reading this right, this brings median TEPS up from 8.6e6 to 1.7e8. This isn't exactly in terms of spmv yet, not sure if a GPU would handle the filtering in this form.
